### PR TITLE
Fix for unban.js

### DIFF
--- a/src/commands/unban.js
+++ b/src/commands/unban.js
@@ -4,21 +4,23 @@ module.exports = {
     args: true,
     usage: '<user>',
 	execute(message, args) {
-        /*
+        
         if(message.member.hasPermission('ADMINISTRATOR')) {
             let flag = false;
             const toUnban = args.join(" ");
             message.guild.fetchBans().then(bans => {
                 bans.forEach(user => {
-                    message.guild.unban(toUnban);
+		if(user.username == toUnban){
+                    message.guild.unban(user);
                     flag = true;
                     return message.channel.send("\:pensive: Unbanned <@" + toUnban.user.id + ">!");
+		    }
                 });
                 if(!flag) return message.channel.send("There is no banned user with the name "+toUnban);
             });
         } else {
             message.channel.send("\:no_entry: You can't unban that person, <@" + message.author.id + ">!");
         }
-        */
+        
 	}
 };


### PR DESCRIPTION
I made a typo in the earlier version by trying to unban a string.. That doesn't work obviously. Now, we unban the given user object coming from message.guild.fetchBans()